### PR TITLE
Enable Built-in NLP with the Graph API

### DIFF
--- a/app.js
+++ b/app.js
@@ -173,6 +173,10 @@ app.get("/profile", (req, res) => {
         res.write(`<li>PERSONA_SALES = ${config.personaSales.id}</li>`);
         res.write("</ul>");
       }
+      if (mode == "nlp" || mode == "all") {
+        GraphAPi.callNLPConfigsAPI();
+        res.write(`<p>Enable Built-in NLP for Page ${config.pageId}</p>`);
+      }
       res.status(200).end();
     } else {
       // Responds with '403 Forbidden' if verify tokens do not match

--- a/services/graph-api.js
+++ b/services/graph-api.js
@@ -250,6 +250,30 @@ module.exports = class GraphAPi {
     });
   }
 
+  static callNLPConfigsAPI() {
+    // Send the HTTP request to the Built-in NLP Configs API
+    // https://developers.facebook.com/docs/graph-api/reference/page/nlp_configs/
+
+    console.log(`Enable Built-in NLP for Page ${config.pageId}`);
+    request(
+      {
+        uri: `${config.mPlatfom}/me/nlp_configs`,
+        qs: {
+          access_token: config.pageAccesToken,
+          nlp_enabled: true
+        },
+        method: "POST"
+      },
+      (error, _res, body) => {
+        if (!error) {
+          console.log("Request sent:", body);
+        } else {
+          console.error("Unable to activate built-in NLP:", error);
+        }
+      }
+    );
+  }
+
   static callFBAEventsAPI(senderPsid, eventName) {
     // Construct the message body
     let requestBody = {


### PR DESCRIPTION
Summary:
Add capability to enable enable Built-in NLP from /profile endpoint

Following instructions in
- https://developers.facebook.com/docs/messenger-platform/built-in-nlp/#enabling_nlp
- https://developers.facebook.com/docs/graph-api/reference/page/nlp_configs/

Differential Revision: D15469772

