### PR TITLE
Handle referral parameters on Get Started

### DIFF
--- a/services/receive.js
+++ b/services/receive.js
@@ -148,9 +148,15 @@ module.exports = class Receive {
 
   // Handles postbacks events
   handlePostback() {
-    // Get the payload of the postback
-    let payload = this.webhookEvent.postback.payload;
-
+    let postback = this.webhookEvent.postback;
+    // Check for the special Get Starded with referral
+    let payload;
+    if (postback.referral && postback.referral.type == "OPEN_THREAD") {
+      payload = postback.referral.ref;
+    } else {
+      // Get the payload of the postback
+      payload = postback.payload;
+    }
     return this.handlePayload(payload);
   }
 


### PR DESCRIPTION
#### Is your pull request related to a problem? Please describe
When visiting an m.me link and presented with a Get Started dialog, the experience will ignore that referral, this PR fixes that. This fixes Issue #17 

#### Describe the solution you'd like
The solution is to handle the special postback request that looks like:
```
{
    "object": "page",
    "entry": [
        {
            "id": "<page-id>",
            "time": 1560447628719,
            "messaging": [
                {
                    "sender": {
                        "id": "<user-id>"
                    },
                    "recipient": {
                        "id": "<page-id>"
                    },
                    "timestamp": 1560447627763,
                    "postback": {
                        "title": "Get Started",
                        "payload": "GET_STARTEED_PAYLOAD",
                        "referral": {
                            "source": "SHORTLINK",
                            "type": "OPEN_THREAD",
                            "ref": "my_test_param"
                        }
                    }
                }
            ]
        }
    ]
}
```
From the above we can confidently assume that the payload `my_test_param` takes precedence over the standard payload `GET_STARTEED_PAYLOAD` into what context is needed to what happens next.

#### Describe alternatives you've considered
By merge in the payload into the regular handlePayload we simplify the way that supported payloads are declared and dealt with.

#### Additional context
This issue was first spotted when people will scan for the first time the QR Code for an event to then be greeted with the generic Hi instead of the specialized message we had prepared.

#### Test plan
On this branch visited:
https://m.me/303005080360340?ref=testing
Got:
![Screenshot 2019-06-13 14 04 08](https://user-images.githubusercontent.com/2464679/59467405-6fd80a00-8de4-11e9-8b7e-bbce84661bf8.png)

Also tested a regular first time Get Stated
![Screenshot 2019-06-13 14 07 28](https://user-images.githubusercontent.com/2464679/59467472-9f871200-8de4-11e9-82e7-a12c428826b6.png)


#### Checklist
- [Y] My code follows the code style of this project.
- [N] My change requires a change to the documentation.
- [NA] I have updated the documentation accordingly.
- [Y] I have read the **[CONTRIBUTING](https://github.com/fbsamples/original-coast-clothing/blob/master/CONTRIBUTING.md)** document.
- [Y] I have added tests to cover my changes.
- [Y] All new and existing tests passed.
- [Y] The title of my pull request is a short description of the requested changes.
- [Y] I have added @jorgeluiso, @rubycalling as reviewers.
- [Y] I have added the label **enhancement** to my pull request.
