### PR TITLE
Send CSAT immediately

### DIFF
--- a/services/survey.js
+++ b/services/survey.js
@@ -36,7 +36,7 @@ module.exports = class Survey {
       ]
     );
 
-    // This is only triggered 1 min after talking with an agent
+    // This is triggered 4 sec after comming back from talking with an agent
     response.delay = "4000";
 
     return response;

--- a/services/survey.js
+++ b/services/survey.js
@@ -37,7 +37,7 @@ module.exports = class Survey {
     );
 
     // This is only triggered 1 min after talking with an agent
-    response.delay = "60000";
+    response.delay = "4000";
 
     return response;
   }


### PR DESCRIPTION
This solves issue #18 
As per the discussion on the issue, the conclusion was to implement displaying the CSAT right away after ending the agent since the user might change the context. 

#### Test plan
![Screenshot 2019-06-28 17 21 46](https://user-images.githubusercontent.com/2464679/60377206-8330cb00-99c9-11e9-8730-5f1a80b78c59.png)

Tested on staging Server
https://www.messenger.com/t/303005080360340