### PR TITLE
Convert postback payloads to uppercase

### DIFF
--- a/services/receive.js
+++ b/services/receive.js
@@ -157,7 +157,7 @@ module.exports = class Receive {
       // Get the payload of the postback
       payload = postback.payload;
     }
-    return this.handlePayload(payload);
+    return this.handlePayload(payload.toUpperCase());
   }
 
   // Handles referral events


### PR DESCRIPTION
This completes the fix for #17, the issue is that PR #19 was missing one usecase.

#### Current behavior

When visiting: https://m.me/OriginalCoastClothing?ref=summer_coupon

First time users get:
This is a default postback message for payload: summer_coupon!

Returning customers would get the coupon
https://m.me/OriginalCoastClothing?ref=summer_coupon

#### Description

On V1 we decided to convert all referral payloads to uppercase. 
https://github.com/fbsamples/original-coast-clothing/blob/v1.0/services/receive.js#L159

PR #19 added the capacity to get first time user payloads but did not gave them the same uppercase treatment. This PR adds that consistency so that the same payload produces the same result.

#### Test plan
On my staging server:
https://m.me/303005080360340?ref=summer_coupon

The payload was successfully parsed as SUMMER_COUPON
![Screenshot 2019-07-01 14 33 57](https://user-images.githubusercontent.com/2464679/60468064-448b5280-9c0d-11e9-8f82-260951898b56.png)

