### PR TITLE
Added warning messages if env variables are not set.

### DIFF
--- a/app.js
+++ b/app.js
@@ -212,6 +212,29 @@ function verifyRequestSignature(req, res, buf) {
   }
 }
 
+// Check if all environment variables are set
+function checkEnvVariables() {
+  var keys = [
+    "pageId",
+    "appId",
+    "pageAccesToken",
+    "appSecret",
+    "verifyToken",
+    "appUrl",
+    "shopUrl"
+  ];
+  keys.forEach(function(key) {
+    if (!config[key]) {
+      console.log(
+        "WARNING: Your configuration file is missing " +
+          key.replace(/([a-zA-Z])(?=[A-Z])/g, "$1_").toUpperCase()
+      );
+    }
+  });
+}
+
+checkEnvVariables();
+
 // listen for requests :)
 var listener = app.listen(config.port, function() {
   console.log("Your app is listening on port " + listener.address().port);

--- a/app.js
+++ b/app.js
@@ -213,43 +213,7 @@ function verifyRequestSignature(req, res, buf) {
 }
 
 // Check if all environment variables are set
-function checkEnvVariables() {
-  var keys = [
-    "pageId",
-    "appId",
-    "pageAccesToken",
-    "appSecret",
-    "verifyToken",
-    "appUrl",
-    "shopUrl"
-  ];
-  keys.forEach(function(key) {
-    if (!config[key]) {
-      console.log(
-        "WARNING: Your configuration file is missing " +
-          key.replace(/([a-zA-Z])(?=[A-Z])/g, "$1_").toUpperCase()
-      );
-    } else {
-      // Check that urls use https
-      if (["appUrl", "shopUrl"].includes(key)) {
-        checkHttpsUrl(key);
-      }
-    }
-  });
-}
-
-function checkHttpsUrl(key) {
-  var url = config[key];
-  if (!url.startsWith("https://")) {
-    console.log(
-      "WARNING: Your " +
-        key.replace(/([a-zA-Z])(?=[A-Z])/g, "$1_").toUpperCase() +
-        ' does not begin with "https://"'
-    );
-  }
-}
-
-checkEnvVariables();
+config.checkEnvVariables();
 
 // listen for requests :)
 var listener = app.listen(config.port, function() {

--- a/app.js
+++ b/app.js
@@ -229,8 +229,24 @@ function checkEnvVariables() {
         "WARNING: Your configuration file is missing " +
           key.replace(/([a-zA-Z])(?=[A-Z])/g, "$1_").toUpperCase()
       );
+    } else {
+      // Check that urls use https
+      if (["appUrl", "shopUrl"].includes(key)) {
+        checkHttpsUrl(key);
+      }
     }
   });
+}
+
+function checkHttpsUrl(key) {
+  var url = config[key];
+  if (!url.startsWith("https://")) {
+    console.log(
+      "WARNING: Your " +
+        key.replace(/([a-zA-Z])(?=[A-Z])/g, "$1_").toUpperCase() +
+        ' does not begin with "https://"'
+    );
+  }
 }
 
 checkEnvVariables();

--- a/services/config.js
+++ b/services/config.js
@@ -11,7 +11,7 @@
 "use strict";
 
 // Use dotenv to read .env vars into Node
-const config = require("dotenv").config();
+require("dotenv").config();
 
 module.exports = {
   // Messenger Platform API
@@ -108,16 +108,6 @@ module.exports = {
   },
 
   checkEnvVariables: function() {
-    if (config.error) {
-      if (config.error.code == "ENOENT") {
-        console.log("WARNING: Your .env file is missing.");
-      } else {
-        console.dir(config.error);
-      }
-      process.exit(1);
-    }
-
-    const parsedVariables = config.parsed;
     var keys = [
       "PAGE_ID",
       "APP_ID",
@@ -128,12 +118,12 @@ module.exports = {
       "SHOP_URL"
     ];
     keys.forEach(function(key) {
-      if (!parsedVariables[key]) {
+      if (!process.env[key]) {
         console.log("WARNING: Your .env file is missing " + key);
       } else {
         // Check that urls use https
         if (["APP_URL", "SHOP_URL"].includes(key)) {
-          const url = parsedVariables[key];
+          const url = process.env[key];
           if (!url.startsWith("https://")) {
             console.log(
               "WARNING: Your " + key + ' does not begin with "https://"'

--- a/services/config.js
+++ b/services/config.js
@@ -13,6 +13,17 @@
 // Use dotenv to read .env vars into Node
 require("dotenv").config();
 
+// Required environment variables
+const ENV_VARS = [
+  "PAGE_ID",
+  "APP_ID",
+  "PAGE_ACCESS_TOKEN",
+  "APP_SECRET",
+  "VERIFY_TOKEN",
+  "APP_URL",
+  "SHOP_URL"
+];
+
 module.exports = {
   // Messenger Platform API
   mPlatformDomain: "https://graph.facebook.com",
@@ -108,18 +119,9 @@ module.exports = {
   },
 
   checkEnvVariables: function() {
-    var keys = [
-      "PAGE_ID",
-      "APP_ID",
-      "PAGE_ACCESS_TOKEN",
-      "APP_SECRET",
-      "VERIFY_TOKEN",
-      "APP_URL",
-      "SHOP_URL"
-    ];
-    keys.forEach(function(key) {
+    ENV_VARS.forEach(function(key) {
       if (!process.env[key]) {
-        console.log("WARNING: Your .env file is missing " + key);
+        console.log("WARNING: Missing the environment variable " + key);
       } else {
         // Check that urls use https
         if (["APP_URL", "SHOP_URL"].includes(key)) {

--- a/services/config.js
+++ b/services/config.js
@@ -11,7 +11,7 @@
 "use strict";
 
 // Use dotenv to read .env vars into Node
-require("dotenv").config();
+const config = require("dotenv").config();
 
 module.exports = {
   // Messenger Platform API
@@ -105,5 +105,42 @@ module.exports = {
 
   get whitelistedDomains() {
     return [this.appUrl, this.shopUrl];
+  },
+
+  checkEnvVariables: function() {
+    if (config.error) {
+      if (config.error.code == "ENOENT") {
+        console.log("WARNING: Your .env file is missing.");
+      } else {
+        console.dir(config.error);
+      }
+      process.exit(1);
+    }
+
+    const parsedVariables = config.parsed;
+    var keys = [
+      "PAGE_ID",
+      "APP_ID",
+      "PAGE_ACCESS_TOKEN",
+      "APP_SECRET",
+      "VERIFY_TOKEN",
+      "APP_URL",
+      "SHOP_URL"
+    ];
+    keys.forEach(function(key) {
+      if (!parsedVariables[key]) {
+        console.log("WARNING: Your .env file is missing " + key);
+      } else {
+        // Check that urls use https
+        if (["APP_URL", "SHOP_URL"].includes(key)) {
+          const url = parsedVariables[key];
+          if (!url.startsWith("https://")) {
+            console.log(
+              "WARNING: Your " + key + ' does not begin with "https://"'
+            );
+          }
+        }
+      }
+    });
   }
 };


### PR DESCRIPTION
#### Problem
Solves #3: Verbose errors from missing environmental variables. 
In this PR I add warning messages if env variables are missing.

#### Test plan
I do a check before the server starts to see if all env variables are set. If not, print warning.
If there is no .env file or the file exists, but no variables are set, you get warnings for all the missing variables:
![empty-dot-env](https://user-images.githubusercontent.com/1098305/61058259-c68a3100-a3ee-11e9-899e-ff62cfce3f91.png)
If .env exists, but only some variables are set, you get warnings for the missing ones:
![semi-empty-dot-env](https://user-images.githubusercontent.com/1098305/61058293-d73aa700-a3ee-11e9-9e8e-550acfcf9c65.png)

If .env has a value for SHOP_URL (or APP_URL), but they do not start with https:// we print a warning:
![https-missing](https://user-images.githubusercontent.com/1098305/61070121-d06b5e80-a405-11e9-8032-991f975f2d77.png)
