### PR TITLE
Clean up f8 reference

### DIFF
--- a/services/curation.js
+++ b/services/curation.js
@@ -26,26 +26,6 @@ module.exports = class Curation {
     let outfit;
 
     switch (payload) {
-      case "F8-2019":
-        response = [
-          Response.genText(
-            i18n.__("get_started.f8-welcome", {
-              userFirstName: this.user.firstName
-            })
-          ),
-          Response.genText(i18n.__("get_started.f8-guidance")),
-          Response.genQuickReply(i18n.__("get_started.f8-help"), [
-            {
-              title: i18n.__("menu.suggestion"),
-              payload: "CURATION"
-            },
-            {
-              title: i18n.__("menu.help"),
-              payload: "CARE_HELP"
-            }
-          ])
-        ];
-        break;
       case "SUMMER_COUPON":
         response = [
           Response.genText(


### PR DESCRIPTION
This reference is now unreachable. Was part of our initial F8 experience but is not longer needed.

#### Test plan
Tested on my Staging
https://m.me/303005080360340?ref=f8-2019

As expected got: 
This is a default postback message for payload: F8-2019!