### PR TITLE
Add support for customer chat plugin payloads.

### DIFF
--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -64,6 +64,9 @@
     "negative": "Thanks for telling us. Sorry to hear that, if there something we can do to turn this let us know",
     "suggestion": "Your suggestion has been recorded for future review by the team. If this is something we need to get back to you right now just comment \"help\""
   },
+  "chat_plugin": {
+    "prompt": "Thanks for visiting our store, be sure to check out all the great styles we have on the summer section."
+  },
   "fallback": {
     "any": "Sorry, but I don’t recognize \"{{message}}\".",
     "attachment": "Thanks for sending this attachment, we can connect you to an agent to review it or we can start over"

--- a/services/receive.js
+++ b/services/receive.js
@@ -193,6 +193,25 @@ module.exports = class Receive {
       response = Order.handlePayload(payload);
     } else if (payload.includes("CSAT")) {
       response = Survey.handlePayload(payload);
+    } else if (payload.includes("CHAT-PLUGIN")) {
+      response = [
+        Response.genText(i18n.__("chat_plugin.prompt")),
+        Response.genText(i18n.__("get_started.guidance")),
+        Response.genQuickReply(i18n.__("get_started.help"), [
+          {
+            title: i18n.__("care.order"),
+            payload: "CARE_ORDER"
+          },
+          {
+            title: i18n.__("care.billing"),
+            payload: "CARE_BILLING"
+          },
+          {
+            title: i18n.__("menu.help"),
+            payload: "CARE_HELP"
+          }
+        ])
+      ];
     } else {
       response = {
         text: `This is a default postback message for payload: ${payload}!`

--- a/services/receive.js
+++ b/services/receive.js
@@ -207,8 +207,8 @@ module.exports = class Receive {
             payload: "CARE_BILLING"
           },
           {
-            title: i18n.__("menu.help"),
-            payload: "CARE_HELP"
+            title: i18n.__("care.other"),
+            payload: "CARE_OTHER"
           }
         ])
       ];


### PR DESCRIPTION
#### Problem
The payload for the chat plugin on the OCC website was not being handled and we would get a default message, as explained in #30 

#### Test Plan
- Go to https://m.me/2358699130818363?ref=OCWEBSITE-CHAT-PLUGIN
- Verify that the chat plugin payload is handled
Here's a video:
https://pxl.cl/H53m