### PR TITLE
Remove mention to Jorge and Laura to avoid mass notifications on forks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,5 +22,4 @@ Also add a link to your own Messenger experience for your reviewer to test the c
 - [ ] I have added tests to cover my changes.
 - [ ] All new and existing tests passed.
 - [ ] The title of my pull request is a short description of the requested changes.
-- [ ] I have added @jorgeluiso, @rubycalling as reviewers.
 - [ ] I have added the label **enhancement** to my pull request.


### PR DESCRIPTION
Removing the line:
- [ ] I have added @jorgeluiso, @rubycalling as reviewers.

This causes unnecessary mentions to our user names on project forks.