### PR TITLE
Add copyright notices to EJS files

### DIFF
--- a/views/footer.ejs
+++ b/views/footer.ejs
@@ -1,3 +1,12 @@
+<% /* %>
+ * Copyright 2019-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Messenger For Original Coast Clothing
+ * https://developers.facebook.com/docs/messenger-platform/getting-started/sample-apps/original-coast-clothing
+ <% */ %>
 </body>
 
 </html>

--- a/views/header.ejs
+++ b/views/header.ejs
@@ -1,4 +1,13 @@
-<!DOCTYPE html>
+<!--
+Copyright 2019-present, Facebook, Inc. All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Messenger For Original Coast Clothing
+https://developers.facebook.com/docs/messenger-platform/getting-started/sample-apps/original-coast-clothing
+-->
+ <!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,4 +1,13 @@
-<% include header %>
+<% /* %>
+ * Copyright 2019-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Messenger For Original Coast Clothing
+ * https://developers.facebook.com/docs/messenger-platform/getting-started/sample-apps/original-coast-clothing
+ <% */ %>
+ <% include header %>
 
 <div class="container">
   <h1>Original Coast Clothing</h1>
@@ -17,7 +26,7 @@
       >
     </li>
     <li>
-      Wan't to build your own?
+      Want to build your own?
       <a
         href="https://developers.facebook.com/docs/messenger-platform/getting-started/sample-apps/original-coast-clothing"
         >DevDocs</a


### PR DESCRIPTION
There were files missing the FB copyright notices.

#### Is your pull request related to a problem? Please describe
The javascript style will include the header once in the client script, while the EJS style of <% /* %> will hide it — thus ensuring that it is displayed only once to someone inspecting the source.

#### Describe the solution you'd like
Ensure that each file has copyright notices, and that the main app script shipped to web clients have it declared exactly once at the the top

#### Describe alternatives you've considered
using only ejs-styled comments so as to not display the copyright notice to the webclient — but it _may_ be a legal requirement to have it shown at least once.


#### Test plan
The internal validation tool should stop complaining about missing copyright notices

#### Checklist
- [✔️ ] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [✔️ ] I have updated the documentation accordingly.
- [✔️ ] I have read the **[CONTRIBUTING](https://github.com/fbsamples/original-coast-clothing/blob/master/CONTRIBUTING.md)** document.
- [n/a] I have added tests to cover my changes.
- [n/a] All new and existing tests passed.
- [✔️ ] The title of my pull request is a short description of the requested changes.
- [n/a] I have added the label **enhancement** to my pull request.
