### PR TITLE
Fix malformed NLP url

### DIFF
--- a/services/graph-api.js
+++ b/services/graph-api.js
@@ -211,7 +211,7 @@ module.exports = class GraphApi {
 
     console.log(`Enable Built-in NLP for Page ${config.pageId}`);
 
-    let url = new URL(`${config.apiUrl}/me/nlp_configs}/me/nlp_configs`);
+    let url = new URL(`${config.apiUrl}/me/nlp_configs`);
     url.search = new URLSearchParams({
       access_token: config.pageAccesToken,
       nlp_enabled: true


### PR DESCRIPTION
#### Is your pull request related to a problem? Please describe
While the [sample tutorial](https://developers.facebook.com/docs/messenger-platform/getting-started/sample-experience), a error was shown for the NLP saying `Unable to activate built-in NLP: Bad Request` while doing the app setup configuration on link
`http://<APP_HOST_URL>/profile?mode=all&verify_token=<VERIFY_TOKEN>`
![image](https://user-images.githubusercontent.com/26100917/167716068-a700d9ba-3c0a-4bd3-8b87-c99bc0fd9db6.png)

#### Describe the solution
The error is a malformed URL on:
https://github.com/fbsamples/original-coast-clothing/blob/main/services/graph-api.js#L214
Just change the line for:
`` let url = new URL(`${config.apiUrl}`/me/nlp_configs); ``

#### Test plan

https://user-images.githubusercontent.com/26100917/167716327-4b4d9310-4234-4b51-b5e2-72277d90ee02.mov



#### Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/fbsamples/original-coast-clothing/blob/main/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.
- [x] I have added the label **enhancement** to my pull request.
