### PR TITLE
New Referral Webhooks on CTM Lead Generation Ads

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "path": "^0.12.7"
   },
   "engines": {
-    "node": ">=12.0 <=18.9.x"
+    "node": ">=12.0"
   },
   "repository": {
     "url": "https://github.com/fbsamples/original-coast-clothing"

--- a/services/lead.js
+++ b/services/lead.js
@@ -22,18 +22,18 @@ module.exports = class Lead {
     this.webhookEvent = webhookEvent;
   }
 
-  handleHandover(metadata) {
-    switch (metadata) {
-      case "messenger_lead_gen_complete":
-        return this.responseForLeadRef();
-      case "messenger_lead_gen_incomplete":
-        return Response.genNuxMessage(this.user);
+  handleReferral(type) {
+    switch (type) {
+      case "LEAD_COMPLETE":
+        return this.responseForLeadComplete();
+      case "LEAD_INCOMPLETE":
+        return null;
     }
 
     return;
   }
 
-  responseForLeadRef() {
+  responseForLeadComplete() {
     var responses = [
       Response.genTextWithPersona(
         i18n.__("wholesale_leadgen.intro", {

--- a/services/receive.js
+++ b/services/receive.js
@@ -180,12 +180,20 @@ module.exports = class Receive {
   // Handles referral events
   handleReferral() {
     // Get the payload of the postback
-    let payload = this.webhookEvent.referral.ref.toUpperCase();
-    if (payload.trim().length === 0) {
-      console.log("Ignore referral with empty payload");
-      return null;
+    let type = this.webhookEvent.referral.type;
+    if (type === "LEAD_COMPLETE" || type === "LEAD_INCOMPLETE") {
+      let lead = new Lead(this.user, this.webhookEvent);
+      return lead.handleReferral(type);
     }
-    return this.handlePayload(payload);
+    if (type === "OPEN_THREAD") {
+      let payload = this.webhookEvent.referral.ref.toUpperCase();
+      if (payload.trim().length === 0) {
+        console.log("Ignore referral with empty payload");
+        return null;
+      }
+      return this.handlePayload(payload);
+    }
+    console.log("Ignore referral of invalid type");
   }
 
   // Handles optins events
@@ -213,8 +221,10 @@ module.exports = class Receive {
     }
     const lead_gen_app_id = 413038776280800; // App id for Messenger Lead Ads
     if (previous_owner_app_id === lead_gen_app_id) {
-      let lead = new Lead(this.user, this.webhookEvent);
-      return lead.handleHandover(metadata);
+      console.log(
+        "Received a handover event from Lead Generation Ad will handle Referral Webhook Instead"
+      );
+      return;
     }
     // We have thread control but no context on what to do, default to New User Experience
     return Response.genNuxMessage(this.user);


### PR DESCRIPTION
Implement the new Referal Webhooks available to Lead Generation with Click to Messenger Ads

As announced on Nov 9, 2022 new referral webhooks are sent on Click To Messenger, Lead Generation Ads
https://developers.facebook.com/docs/messenger-platform/discovery/lead-generation-ads-in-messenger

This change supports the bot response after a lead is complete. It implements the response that happend after this lead ad ends:
https://www.facebook.com/ads/experience/confirmation/?experience_id=2170497373124589

The demo ad is also linked in the documentation mentioned above as the Sample Lead Generation Ad.
